### PR TITLE
Fix#22 Create a wallet without trying to post a bounty

### DIFF
--- a/src/components/App/index.jsx
+++ b/src/components/App/index.jsx
@@ -163,6 +163,7 @@ class App extends Component {
 
   onWalletChangeHandler(store) {
     this.setState({isUnlocked: store});
+    this.getWallets();
   }
 
   removeRequest(title, id/*, success*/) {

--- a/src/components/App/index.jsx
+++ b/src/components/App/index.jsx
@@ -53,8 +53,17 @@ class App extends Component {
   }
 
   componentDidMount() {
-    this.getWallets();
     this.getData();
+    this.timer = setInterval(() => {
+      this.getWallets();
+    }, 5000);
+  }
+
+  componentWillUnmount() {
+    if (this.timer) {
+      this.timer.clearInterval();
+      this.timer = null;
+    }
   }
 
   render() {

--- a/src/components/BountyCreate/index.jsx
+++ b/src/components/BountyCreate/index.jsx
@@ -82,12 +82,14 @@ class BountyCreate extends Component {
     this.modal.open();
   }
 
-  onWalletChangeHandler(store) {
+  onWalletChangeHandler(didUnlock, store) {
     const { props: { onWalletChange } } = this;
     if (onWalletChange) {
       onWalletChange(store);
     }
-    this.createBounty();
+    if (didUnlock) {
+      this.createBounty();
+    }
   }
 
   onClearAll() {

--- a/src/components/ModalPassword/index.jsx
+++ b/src/components/ModalPassword/index.jsx
@@ -39,10 +39,19 @@ class ModalPassword extends Component {
   }
 
   componentWillMount() {
-    const { props: { walletList } } = this;
-    const { state: { address } } = this;
-    if (walletList && walletList.length > 0) {
-      this.updateBalance(walletList[address]);
+    this.timer = setInterval(() => {
+      const { props: { walletList } } = this;
+      const { state: { address } } = this;
+      if (walletList && walletList.length > 0) {
+        this.updateBalance(walletList[address]);
+      }
+    }, 5000);
+  }
+
+  componentWillUnmount() {
+    if (this.timer) {
+      this.timer.clearInterval();
+      this.timer = null;
     }
   }
 

--- a/src/components/ModalPassword/index.jsx
+++ b/src/components/ModalPassword/index.jsx
@@ -29,7 +29,7 @@ class ModalPassword extends Component {
     this.onCloseClick = this.onCloseClick.bind(this);
     this.onKeyPress = this.onKeyPress.bind(this);
     this.onUnlockClick = this.onUnlockClick.bind(this);
-    this.onUnlock = this.onUnlock.bind(this);
+    this.unlockWallet = this.unlockWallet.bind(this);
     this.createWallet = this.createWallet.bind(this);
     this.open = this.open.bind(this);
     this.close = this.close.bind(this);
@@ -169,13 +169,13 @@ class ModalPassword extends Component {
     const { state: { address, password } } = this;
     const { props: { walletList } } = this;
     if (walletList && walletList.length > 0) {
-      this.onUnlock(walletList[address], password);
+      this.unlockWallet(walletList[address], password);
     } else {
       this.createWallet(password);
     }
   }
 
-  onUnlock(address, password) {
+  unlockWallet(address, password) {
     const { props: { url } } = this;
     this.setState({ unlocking: true, error: false });
     const http = new HttpAccount(url);

--- a/src/components/ModalPassword/index.jsx
+++ b/src/components/ModalPassword/index.jsx
@@ -129,10 +129,10 @@ class ModalPassword extends Component {
     );
   }
 
-  onWalletChangeHandler() {
+  onWalletChangeHandler(didUnlock = false) {
     const { props: { onWalletChange }, state: { store } } = this;
     if (onWalletChange) {
-      onWalletChange(store);
+      onWalletChange(didUnlock, store);
     }
   }
 
@@ -184,7 +184,7 @@ class ModalPassword extends Component {
     return http.unlockWallet(address, password).then(success => {
       this.setState({ unlocking: false, error: !success });
       if (success) {
-        this.onWalletChangeHandler();
+        this.onWalletChangeHandler(true);
         this.close();
       }
       this.removeAccountRequest(strings.requestUnlockWallet, uuid);
@@ -200,7 +200,7 @@ class ModalPassword extends Component {
     return http.createWallet(password).then(success => {
       this.setState({ unlocking: false, error: !success });
       if (success) {
-        this.onWalletChangeHandler();
+        this.onWalletChangeHandler(false);
         this.close();
       }
       this.removeAccountRequest(strings.requestCreateWallet, uuid);

--- a/src/components/__tests__/App.test.js
+++ b/src/components/__tests__/App.test.js
@@ -859,8 +859,7 @@ it('calls setState with account: true when calling onAccountSet(true)', () => {
 
   instance.onWalletChangeHandler(true);
 
-  expect(setState).toHaveBeenCalledTimes(1);
-  expect(setState).toHaveBeenCalledWith({isUnlocked: true});
+  expect(setState.mock.calls[0][0]).toEqual({isUnlocked: true});
 });
 
 it('calls setState with account: false when calling onAccountSet(false)', () => {
@@ -871,8 +870,7 @@ it('calls setState with account: false when calling onAccountSet(false)', () => 
 
   instance.onWalletChangeHandler(false);
 
-  expect(setState).toHaveBeenCalledTimes(1);
-  expect(setState).toHaveBeenCalledWith({isUnlocked: false});
+  expect(setState.mock.calls[0][0]).toEqual({isUnlocked: false});
 });
 
 // it('opens the modal when onPostError is called', (done) => {

--- a/src/components/__tests__/BountyCreate.test.js
+++ b/src/components/__tests__/BountyCreate.test.js
@@ -405,7 +405,7 @@ it('opens the modal if isUnlocked not set on create click', () => {
   expect(wrapper.find('.ModalContent')).toHaveLength(1);
 });
 
-it('calls create after modal is successfully closed', () => {
+it('calls create after modal is successfully closed & returns unlocked', () => {
   const createBounty = jest.spyOn(BountyCreate.prototype, 'createBounty');
   const onWalletChange = jest.fn();
   const walletList = [];
@@ -422,7 +422,7 @@ it('calls create after modal is successfully closed', () => {
   wrapper.setState({files: files, uploading: false});
   const instance = wrapper.instance();
 
-  instance.onWalletChangeHandler(false);
+  instance.onWalletChangeHandler(true, false);
 
   expect(createBounty).toHaveBeenCalledTimes(1);
 });
@@ -443,7 +443,7 @@ it('calls onWalletChange when modal closed and password checked', () => {
   wrapper.setState({files: files, uploading: false});
   const instance = wrapper.instance();
 
-  instance.onWalletChangeHandler(true);
+  instance.onWalletChangeHandler(true, true);
 
   expect(onWalletChange).toHaveBeenCalledTimes(1);
   expect(onWalletChange).toHaveBeenCalledWith(true);
@@ -465,7 +465,7 @@ it('calls onWalletChange when modal closed and password not checked', () => {
   wrapper.setState({files: files, uploading: false});
   const instance = wrapper.instance();
 
-  instance.onWalletChangeHandler(false);
+  instance.onWalletChangeHandler(false, false);
 
   expect(onWalletChange).toHaveBeenCalledTimes(1);
   expect(onWalletChange).toHaveBeenCalledWith(false);

--- a/src/components/__tests__/ModalPassword.test.js
+++ b/src/components/__tests__/ModalPassword.test.js
@@ -156,7 +156,7 @@ it('calls onWalletChange with true when store is true', () => {
   instance.onWalletChangeHandler();
 
   expect(onWalletChange).toHaveBeenCalledTimes(1);
-  expect(onWalletChange).toHaveBeenCalledWith(true);
+  expect(onWalletChange.mock.calls[0][0]).toEqual(false, true);
 });
 
 it('call onWalletChange with false when store is false', () => {
@@ -172,7 +172,39 @@ it('call onWalletChange with false when store is false', () => {
   instance.onWalletChangeHandler();
 
   expect(onWalletChange).toHaveBeenCalledTimes(1);
-  expect(onWalletChange).toHaveBeenCalledWith(false);
+  expect(onWalletChange).toHaveBeenCalledWith(false, false);
+});
+
+it('passes didUnlock parameter in onWalletChangeHandler to onWalletChange', () => {
+  const onWalletChange = jest.fn();
+  const walletList = [];
+  const wrapper = mount(
+    <ModalPassword walletList={walletList}
+      onWalletChange={onWalletChange} />
+  );
+  wrapper.setState({store: false});
+  const instance = wrapper.instance();
+
+  instance.onWalletChangeHandler(true);
+
+  expect(onWalletChange).toHaveBeenCalledTimes(1);
+  expect(onWalletChange).toHaveBeenCalledWith(true, false);
+});
+
+it('passes didUnlock parameter in onWalletChangeHandler to onWalletChange', () => {
+  const onWalletChange = jest.fn();
+  const walletList = [];
+  const wrapper = mount(
+    <ModalPassword walletList={walletList}
+      onWalletChange={onWalletChange} />
+  );
+  wrapper.setState({store: false});
+  const instance = wrapper.instance();
+
+  instance.onWalletChangeHandler(false);
+
+  expect(onWalletChange).toHaveBeenCalledTimes(1);
+  expect(onWalletChange).toHaveBeenCalledWith(false, false);
 });
 
 it('shows given walletList as options in dropdown', () => {

--- a/src/components/__tests__/ModalPassword.test.js
+++ b/src/components/__tests__/ModalPassword.test.js
@@ -289,17 +289,17 @@ it('does not call onUnlockAccount when a key other than enter is pressed', () =>
 });
 
 it('unlocks with the values entered in the state for unlockWallet', () => {
-  const onUnlock = jest.spyOn(ModalPassword.prototype, 'onUnlock');
+  const unlockWallet = jest.spyOn(ModalPassword.prototype, 'unlockWallet');
   const url = 'https://localhost:8080';
   const walletList = ['asdf','demo','omed'];
   const wrapper = mount(<ModalPassword url={url} walletList={walletList}/>);
   wrapper.setState({open: true, error: false, password: 'password'});
 
-  onUnlock.mockClear();
+  unlockWallet.mockClear();
 
   wrapper.find('.flat').simulate('click');
 
-  expect(onUnlock).toHaveBeenCalledWith('asdf', 'password');
+  expect(unlockWallet).toHaveBeenCalledWith('asdf', 'password');
 });
 
 it('creates with the values entered in the state for unlockWallet', () => {
@@ -327,7 +327,7 @@ it('does call onWalletChange with false when store is false after unlocking', (d
   wrapper.setState({store: false});
   const instance = wrapper.instance();
 
-  instance.onUnlock('address', 'password')
+  instance.unlockWallet('address', 'password')
     .then(() => {
       try {
         expect(onWalletChange).toHaveBeenCalledTimes(1);
@@ -351,7 +351,7 @@ it('does call onWalletChange when store is true after unlocking', (done) => {
   wrapper.setState({store: true});
   const instance = wrapper.instance();
 
-  instance.onUnlock('address', 'password')
+  instance.unlockWallet('address', 'password')
     .then(() => {
       try {
         expect(mockUnlockWallet).toHaveBeenCalledTimes(1);
@@ -371,7 +371,7 @@ it('closes the modal when unlock succeeds', (done) => {
   wrapper.setState({store: true});
   const instance = wrapper.instance();
 
-  instance.onUnlock('address', 'password')
+  instance.unlockWallet('address', 'password')
     .then(() => {
       try {
         expect(mockUnlockWallet).toHaveBeenCalledTimes(1);
@@ -401,7 +401,7 @@ it('does not close when unlock fails', (done) => {
   wrapper.setState({store: true});
   const instance = wrapper.instance();
 
-  instance.onUnlock('address', 'password')
+  instance.unlockWallet('address', 'password')
     .then(() => {
       try {
         expect(mockBadUnlock).toHaveBeenCalledTimes(1);
@@ -421,7 +421,7 @@ it('sets unlocking:true, error: false when unlock starts', () => {
   const setState = jest.spyOn(ModalPassword.prototype, 'setState');
   const instance = wrapper.instance();
 
-  instance.onUnlock('address', 'password');
+  instance.unlockWallet('address', 'password');
 
   expect(setState).toHaveBeenCalledWith({unlocking: true, error: false});
 });
@@ -435,7 +435,7 @@ it('sets unlocking:false, error:false when unlock succeeds', (done) => {
   setState.mockClear();
   const instance = wrapper.instance();
 
-  instance.onUnlock('address', 'password')
+  instance.unlockWallet('address', 'password')
     .then(() => {
       try{
         expect(setState.mock.calls[1][0]).toEqual({unlocking: false, error: false});
@@ -469,7 +469,7 @@ it('does not call onWalletChange when unlock fails', (done) => {
   wrapper.setState({store: true});
   const instance = wrapper.instance();
 
-  instance.onUnlock('address', 'password')
+  instance.unlockWallet('address', 'password')
     .then(() => {
       try {
         expect(mockBadUnlock).toHaveBeenCalledTimes(1);
@@ -789,7 +789,7 @@ it('should call addCreateBountyRequest and removeCreateBountyRequest in unlockWa
   const instance = wrapper.instance();
 
   // act
-  instance.onUnlock()
+  instance.unlockWallet()
     .then(() => {
       // assert
       try {
@@ -816,7 +816,7 @@ it('should call addRequest and removeRequest in unlockWallet', (done) => {
   const instance = wrapper.instance();
 
   // act
-  instance.onUnlock()
+  instance.unlockWallet()
     .then(() => {
       // assert
       try {


### PR DESCRIPTION
Stops posting bounties when the user creates a new wallet. 

It also polls for data about the accounts and balances so that information stays up to date. 